### PR TITLE
Run actions

### DIFF
--- a/autoapi/_parser.py
+++ b/autoapi/_parser.py
@@ -2,8 +2,8 @@ import collections
 import os
 
 import astroid
-import astroid.builder
-import astroid.manager
+from astroid.builder import AstroidBuilder
+from astroid.manager import AstroidBuilder
 import sphinx.util.docstrings
 
 from . import _astroid_utils
@@ -38,7 +38,7 @@ class Parser:
                 module_parts.appendleft(module_part)
 
         module_name = ".".join(module_parts)
-        node = astroid.builder.AstroidBuilder(manager.AstroidManager()).file_build(file_path, module_name)
+        node = AstroidBuilder(AstroidManager()).file_build(file_path, module_name)
         return self.parse(node)
 
     def parse_file(self, file_path):

--- a/autoapi/_parser.py
+++ b/autoapi/_parser.py
@@ -3,7 +3,7 @@ import os
 
 import astroid
 from astroid.builder import AstroidBuilder
-from astroid.manager import AstroidBuilder
+from astroid.manager import AstroidManager
 import sphinx.util.docstrings
 
 from . import _astroid_utils

--- a/autoapi/_parser.py
+++ b/autoapi/_parser.py
@@ -3,6 +3,7 @@ import os
 
 import astroid
 import astroid.builder
+import astroid.manager
 import sphinx.util.docstrings
 
 from . import _astroid_utils
@@ -37,7 +38,7 @@ class Parser:
                 module_parts.appendleft(module_part)
 
         module_name = ".".join(module_parts)
-        node = astroid.builder.AstroidBuilder().file_build(file_path, module_name)
+        node = astroid.builder.AstroidBuilder(manager.AstroidManager()).file_build(file_path, module_name)
         return self.parse(node)
 
     def parse_file(self, file_path):

--- a/docs/changes/536.bugfix.rst
+++ b/docs/changes/536.bugfix.rst
@@ -1,0 +1,2 @@
+Update the supported versions of astroid.
+Fix the breaking change to Import and pass in the AstroidManager to the AstroidBuilder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    'astroid>=2.7;python_version<"3.12"',
-    'astroid>=3;python_version>="3.12"',
+    'astroid~=3.0;python_version<"3.12"',
+    'astroid~=4.0;python_version>="3.12"',
     "Jinja2",
     "PyYAML",
     "sphinx>=7.4.0",


### PR DESCRIPTION
AstroidManager now needs to be directly imported in version 4.0.0

Unsure if there are any other breaking changes in 4.0.0